### PR TITLE
List library dependencies in podspec.

### DIFF
--- a/ios/flutter_ijk.podspec
+++ b/ios/flutter_ijk.podspec
@@ -18,5 +18,6 @@ A new Flutter plugin.
   s.vendored_frameworks = 'IJKMediaFramework.framework'
 
   s.ios.deployment_target = '8.0'
+  s.library = ['z', 'c++']
 end
 


### PR DESCRIPTION
IJK requires libz and libc++ to function.